### PR TITLE
Improve CSV folder dropdown

### DIFF
--- a/DropFile_I3d/CsvRemoveForm.cs
+++ b/DropFile_I3d/CsvRemoveForm.cs
@@ -14,26 +14,18 @@ namespace ICam4DSetup
         private HashSet<string> screwKeys = new();
         private HashSet<string> healingKeys = new();
 
-        public CsvRemoveForm()
+        public CsvRemoveForm(string csvPath)
         {
             InitializeComponent();
-
-            using OpenFileDialog openFileDialog = new OpenFileDialog
+            localCsvPath = csvPath;
+            if (File.Exists(localCsvPath))
             {
-                Title = "Select your ICamBody Library CSV file",
-                Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-                InitialDirectory = @"C:\I3D_Systems\"
-            };
-
-            if (openFileDialog.ShowDialog() == DialogResult.OK)
-            {
-                localCsvPath = openFileDialog.FileName;
                 LoadCsv();
             }
             else
             {
-                MessageBox.Show("No file selected. Closing.");
-                this.Close();
+                MessageBox.Show($"CSV not found: {localCsvPath}");
+                Close();
             }
         }
 

--- a/DropFile_I3d/Form1.Designer.cs
+++ b/DropFile_I3d/Form1.Designer.cs
@@ -44,7 +44,6 @@ namespace DropFile_I3d
             button3 = new Button();
             button1 = new Button();
             comboBoxCsvDir = new ComboBox();
-            buttonSelectCsvDir = new Button();
             toolTip1 = new ToolTip(components);
             label1 = new Label();
             label2 = new Label();
@@ -181,15 +180,6 @@ namespace DropFile_I3d
             comboBoxCsvDir.Size = new Size(306, 33);
             comboBoxCsvDir.TabIndex = 28;
             // 
-            // buttonSelectCsvDir
-            // 
-            buttonSelectCsvDir.Location = new Point(330, 25);
-            buttonSelectCsvDir.Name = "buttonSelectCsvDir";
-            buttonSelectCsvDir.Size = new Size(207, 38);
-            buttonSelectCsvDir.TabIndex = 29;
-            buttonSelectCsvDir.Text = "Browse CSV Folder";
-            buttonSelectCsvDir.UseVisualStyleBackColor = true;
-            buttonSelectCsvDir.Click += buttonSelectCsvDir_Click;
             // 
             // label1
             // 
@@ -224,7 +214,6 @@ namespace DropFile_I3d
             // 
             // groupBox2
             // 
-            groupBox2.Controls.Add(buttonSelectCsvDir);
             groupBox2.Controls.Add(button2);
             groupBox2.Controls.Add(comboBoxCsvDir);
             groupBox2.Controls.Add(buttonRemove);
@@ -311,6 +300,5 @@ namespace DropFile_I3d
         private Label labelVersion;
         private Button button2;
         private ComboBox comboBoxCsvDir;
-        private Button buttonSelectCsvDir;
     }
 }


### PR DESCRIPTION
## Summary
- auto-populate available `ICamBody Library` folders on startup
- use selected folder when adding or removing screws/healing caps
- remove old browse button
- update remove form to accept CSV path

## Testing
- `msbuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ddd0ed8883219a4b787904e76c38