### PR TITLE
Add drag-and-drop ICamBody import

### DIFF
--- a/DropFile_I3d/Form1.Designer.cs
+++ b/DropFile_I3d/Form1.Designer.cs
@@ -230,6 +230,7 @@ namespace DropFile_I3d
             // 
             // button2
             // 
+            button2.AllowDrop = true;
             button2.Location = new Point(285, 86);
             button2.Name = "button2";
             button2.Size = new Size(238, 59);
@@ -237,6 +238,8 @@ namespace DropFile_I3d
             button2.Text = "Add ICamBodies";
             button2.UseVisualStyleBackColor = true;
             button2.Click += button2_Click;
+            button2.DragEnter += button2_DragEnter;
+            button2.DragDrop += button2_DragDrop;
             // 
             // groupBox3
             // 

--- a/DropFile_I3d/Form1.cs
+++ b/DropFile_I3d/Form1.cs
@@ -8,6 +8,8 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Reflection;
@@ -340,7 +342,131 @@ namespace DropFile_I3d
 
         private void button2_Click(object sender, EventArgs e)
         {
+            using var dialog = new FolderBrowserDialog();
+            if (dialog.ShowDialog() == DialogResult.OK)
+            {
+                ProcessIcamBodyFolder(dialog.SelectedPath);
+            }
+        }
 
+        private void button2_DragEnter(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                var files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files.Length == 1 && Directory.Exists(files[0]))
+                    e.Effect = DragDropEffects.Copy;
+                else
+                    e.Effect = DragDropEffects.None;
+            }
+        }
+
+        private void button2_DragDrop(object sender, DragEventArgs e)
+        {
+            var files = (string[])e.Data.GetData(DataFormats.FileDrop);
+            if (files.Length > 0 && Directory.Exists(files[0]))
+            {
+                ProcessIcamBodyFolder(files[0]);
+            }
+        }
+
+        private void ProcessIcamBodyFolder(string sourceFolder)
+        {
+            try
+            {
+                string baseDir = SelectedCsvDirectory;
+                if (string.IsNullOrWhiteSpace(baseDir) || !Directory.Exists(baseDir))
+                {
+                    MessageBox.Show("No ICamBody Library selected.");
+                    return;
+                }
+
+                string csvPath = Path.Combine(baseDir, "ICamBody Library.csv");
+                if (!File.Exists(csvPath))
+                {
+                    MessageBox.Show($"CSV file not found: {csvPath}");
+                    return;
+                }
+
+                string folderName = Path.GetFileName(sourceFolder.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+                // Copy folder into MU-RP
+                string muRpFolder = Path.Combine(baseDir, "MU-RP", folderName);
+                CopyDirectory(sourceFolder, muRpFolder);
+
+                // Determine target directories from column F
+                var csvLines = File.ReadAllLines(csvPath).ToList();
+                var directories = new HashSet<string>();
+                foreach (var line in csvLines.Skip(1))
+                {
+                    var parts = line.Split('\t');
+                    if (parts.Length > 5 && !string.IsNullOrWhiteSpace(parts[5]))
+                        directories.Add(parts[5].Trim());
+                }
+
+                foreach (var dir in directories)
+                {
+                    if (dir.Equals("ICamRef", StringComparison.OrdinalIgnoreCase) ||
+                        dir.Equals("MU-RP", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string target = Path.Combine(baseDir, dir, folderName);
+                    CopyDirectory(sourceFolder, target);
+                }
+
+                var header = csvLines.First();
+                var dataLines = csvLines.Skip(1).ToList();
+                var existing = new HashSet<string>(dataLines);
+                var newLines = new List<string>();
+
+                foreach (var line in dataLines)
+                {
+                    var parts = line.Split('\t');
+                    if (parts.Length <= 6 || parts[1].Trim().Equals("ICamRef", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var copy = (string[])parts.Clone();
+                    copy[4] = folderName;
+                    copy[6] = folderName + ".ad";
+                    var newLine = string.Join('\t', copy);
+                    if (!existing.Contains(newLine))
+                    {
+                        newLines.Add(newLine);
+                        existing.Add(newLine);
+                    }
+                }
+
+                dataLines.AddRange(newLines);
+
+                var healingLines = dataLines.Where(l => l.Split('\t')[1].Trim().Equals("ICamRef", StringComparison.OrdinalIgnoreCase));
+                var screwLines = dataLines.Except(healingLines);
+                screwLines = screwLines.OrderBy(l => l.Split('\t')[4]).ThenBy(l => l.Split('\t')[1]);
+                dataLines = screwLines.Concat(healingLines).ToList();
+
+                File.WriteAllLines(csvPath, new[] { header }.Concat(dataLines), Encoding.UTF8);
+
+                MessageBox.Show("ICamBodies added to library.");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Error adding ICamBodies: " + ex.Message);
+            }
+        }
+
+        private void CopyDirectory(string sourceDir, string targetDir)
+        {
+            foreach (string dir in Directory.GetDirectories(sourceDir, "*", SearchOption.AllDirectories))
+            {
+                string targetSubDir = dir.Replace(sourceDir, targetDir);
+                Directory.CreateDirectory(targetSubDir);
+            }
+
+            foreach (string fileName in Directory.GetFiles(sourceDir, "*.*", SearchOption.AllDirectories))
+            {
+                string targetFilePath = fileName.Replace(sourceDir, targetDir);
+                Directory.CreateDirectory(Path.GetDirectoryName(targetFilePath)!);
+                File.Copy(fileName, targetFilePath, true);
+            }
         }
 
         private void PopulateCsvDirectories()


### PR DESCRIPTION
## Summary
- enable drag-and-drop on **Add ICamBodies** button
- copy dropped folder into MU‑RP and other library directories
- append screw entries to `ICamBody Library.csv`

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6874e12d7d4c83218e62b922b216d639