### PR TITLE
Remember last selected ICam directory

### DIFF
--- a/DropFile_I3d/App.config
+++ b/DropFile_I3d/App.config
@@ -10,6 +10,9 @@
             <setting name="HideImplantHowTo" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="LastCsvDir" serializeAs="String">
+                <value></value>
+            </setting>
         </ICam4DSetup.Properties.Settings>
     </userSettings>
 </configuration>

--- a/DropFile_I3d/Form1.cs
+++ b/DropFile_I3d/Form1.cs
@@ -36,6 +36,7 @@ namespace DropFile_I3d
         {
             InitializeComponent();
             comboBoxCsvDir.DropDownStyle = ComboBoxStyle.DropDownList;
+            comboBoxCsvDir.SelectedIndexChanged += ComboBoxCsvDir_SelectedIndexChanged;
             iniFile = new IniFile(Path.Combine(Application.StartupPath, "config.ini"));
             labelVersion.Text = "V" + Assembly.GetExecutingAssembly()
                                      .GetName().Version?.ToString();
@@ -485,7 +486,25 @@ namespace DropFile_I3d
             }
 
             if (comboBoxCsvDir.Items.Count > 0)
-                comboBoxCsvDir.SelectedIndex = 0;
+            {
+                string lastPath = Properties.Settings.Default.LastCsvDir;
+                int index = -1;
+                if (!string.IsNullOrWhiteSpace(lastPath))
+                {
+                    index = comboBoxCsvDir.Items.Cast<FolderItem>().ToList()
+                        .FindIndex(fi => fi.Path.Equals(lastPath, StringComparison.OrdinalIgnoreCase));
+                }
+                comboBoxCsvDir.SelectedIndex = index >= 0 ? index : 0;
+            }
+        }
+
+        private void ComboBoxCsvDir_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (comboBoxCsvDir.SelectedItem is FolderItem item)
+            {
+                Properties.Settings.Default.LastCsvDir = item.Path;
+                Properties.Settings.Default.Save();
+            }
         }
 
         private void label3_Click(object sender, EventArgs e)

--- a/DropFile_I3d/Properties/Settings.Designer.cs
+++ b/DropFile_I3d/Properties/Settings.Designer.cs
@@ -38,5 +38,20 @@ namespace DropFile_I3d.Properties
                 this["HideImplantHowTo"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSetting()]
+        [global::System.Diagnostics.DebuggerNonUserCode()]
+        [global::System.Configuration.DefaultSettingValue("")]
+        public string LastCsvDir
+        {
+            get
+            {
+                return ((string)(this["LastCsvDir"]));
+            }
+            set
+            {
+                this["LastCsvDir"] = value;
+            }
+        }
     }
 }

--- a/DropFile_I3d/Properties/Settings.settings
+++ b/DropFile_I3d/Properties/Settings.settings
@@ -5,5 +5,8 @@
     <Setting Name="HideImplantHowTo" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="LastCsvDir" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary
- allow the application to remember the previously chosen CSV directory
- store the directory path in user settings and restore it on launch

## Testing
- `apt-get update`
- `apt-get install -y apt-transport-https`
- ❌ `dotnet build Imetric_Installer.sln -c Release` *(failed: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e8f1cde4832184cab1389267beda