### PR TITLE
Add More Tools menu with placeholder windows

### DIFF
--- a/DropFile_I3d/ComingSoonForm.Designer.cs
+++ b/DropFile_I3d/ComingSoonForm.Designer.cs
@@ -1,0 +1,60 @@
+namespace DropFile_I3d
+{
+    partial class ComingSoonForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private Label labelMessage;
+        private Button buttonOk;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            labelMessage = new Label();
+            buttonOk = new Button();
+            SuspendLayout();
+            // 
+            // labelMessage
+            // 
+            labelMessage.AutoSize = true;
+            labelMessage.Location = new System.Drawing.Point(30, 23);
+            labelMessage.Name = "labelMessage";
+            labelMessage.Size = new System.Drawing.Size(164, 25);
+            labelMessage.TabIndex = 0;
+            labelMessage.Text = "Feature coming soon";
+            // 
+            // buttonOk
+            // 
+            buttonOk.Location = new System.Drawing.Point(74, 63);
+            buttonOk.Name = "buttonOk";
+            buttonOk.Size = new System.Drawing.Size(75, 34);
+            buttonOk.TabIndex = 1;
+            buttonOk.Text = "OK";
+            buttonOk.UseVisualStyleBackColor = true;
+            buttonOk.Click += (sender, e) => Close();
+            // 
+            // ComingSoonForm
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(230, 120);
+            Controls.Add(buttonOk);
+            Controls.Add(labelMessage);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "ComingSoonForm";
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Coming Soon";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/DropFile_I3d/ComingSoonForm.cs
+++ b/DropFile_I3d/ComingSoonForm.cs
@@ -1,0 +1,12 @@
+using System.Windows.Forms;
+
+namespace DropFile_I3d
+{
+    public partial class ComingSoonForm : Form
+    {
+        public ComingSoonForm()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DropFile_I3d/Form1.Designer.cs
+++ b/DropFile_I3d/Form1.Designer.cs
@@ -34,6 +34,11 @@ namespace DropFile_I3d
             labelProgress = new Label();
             folderBrowserDialog = new FolderBrowserDialog();
             openFileDialog = new OpenFileDialog();
+            menuStrip1 = new MenuStrip();
+            moreToolsMenuItem = new ToolStripMenuItem();
+            createNewLibraryMenuItem = new ToolStripMenuItem();
+            hotSwapHelperMenuItem = new ToolStripMenuItem();
+            troubleshootingMenuItem = new ToolStripMenuItem();
             buttonInstallDriver = new Button();
             buttonIScan3d = new Button();
             buttonInstallZip7 = new Button();
@@ -56,6 +61,7 @@ namespace DropFile_I3d
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             groupBox2.SuspendLayout();
             groupBox3.SuspendLayout();
+            menuStrip1.SuspendLayout();
             SuspendLayout();
             // 
             // labelProgress
@@ -282,6 +288,44 @@ namespace DropFile_I3d
             groupBox3.Size = new Size(553, 200);
             groupBox3.TabIndex = 24;
             groupBox3.TabStop = false;
+            //
+            // menuStrip1
+            //
+            menuStrip1.ImageScalingSize = new Size(24, 24);
+            menuStrip1.Items.AddRange(new ToolStripItem[] { moreToolsMenuItem });
+            menuStrip1.Location = new Point(0, 0);
+            menuStrip1.Name = "menuStrip1";
+            menuStrip1.Size = new Size(624, 33);
+            menuStrip1.TabIndex = 30;
+            menuStrip1.Text = "menuStrip1";
+            //
+            // moreToolsMenuItem
+            //
+            moreToolsMenuItem.DropDownItems.AddRange(new ToolStripItem[] { createNewLibraryMenuItem, hotSwapHelperMenuItem, troubleshootingMenuItem });
+            moreToolsMenuItem.Name = "moreToolsMenuItem";
+            moreToolsMenuItem.Size = new Size(114, 29);
+            moreToolsMenuItem.Text = "More Tools";
+            //
+            // createNewLibraryMenuItem
+            //
+            createNewLibraryMenuItem.Name = "createNewLibraryMenuItem";
+            createNewLibraryMenuItem.Size = new Size(248, 34);
+            createNewLibraryMenuItem.Text = "Create New Library";
+            createNewLibraryMenuItem.Click += createNewLibraryMenuItem_Click;
+            //
+            // hotSwapHelperMenuItem
+            //
+            hotSwapHelperMenuItem.Name = "hotSwapHelperMenuItem";
+            hotSwapHelperMenuItem.Size = new Size(248, 34);
+            hotSwapHelperMenuItem.Text = "HotSwap Helper";
+            hotSwapHelperMenuItem.Click += hotSwapHelperMenuItem_Click;
+            //
+            // troubleshootingMenuItem
+            //
+            troubleshootingMenuItem.Name = "troubleshootingMenuItem";
+            troubleshootingMenuItem.Size = new Size(248, 34);
+            troubleshootingMenuItem.Text = "Troubleshooting";
+            troubleshootingMenuItem.Click += troubleshootingMenuItem_Click;
             // 
             // Form1
             // 
@@ -289,6 +333,7 @@ namespace DropFile_I3d
             AutoScaleMode = AutoScaleMode.Font;
             AutoSizeMode = AutoSizeMode.GrowAndShrink;
             ClientSize = new Size(624, 827);
+            Controls.Add(menuStrip1);
             Controls.Add(label2);
             Controls.Add(label1);
             Controls.Add(groupBox3);
@@ -307,6 +352,8 @@ namespace DropFile_I3d
             groupBox2.ResumeLayout(false);
             groupBox2.PerformLayout();
             groupBox3.ResumeLayout(false);
+            menuStrip1.ResumeLayout(false);
+            menuStrip1.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
 
@@ -337,5 +384,10 @@ namespace DropFile_I3d
         private ComboBox comboBoxCsvDir;
         private Label label3;
         private Label label4;
+        private MenuStrip menuStrip1;
+        private ToolStripMenuItem moreToolsMenuItem;
+        private ToolStripMenuItem createNewLibraryMenuItem;
+        private ToolStripMenuItem hotSwapHelperMenuItem;
+        private ToolStripMenuItem troubleshootingMenuItem;
     }
 }

--- a/DropFile_I3d/Form1.cs
+++ b/DropFile_I3d/Form1.cs
@@ -523,14 +523,25 @@ namespace DropFile_I3d
             groupBox2.Visible = false;
         }
 
-        private void libraryCreatorMenuItem_Click(object sender, EventArgs e)
+        private void createNewLibraryMenuItem_Click(object sender, EventArgs e)
         {
-            MessageBox.Show("Library Creator not implemented yet.");
+            ShowComingSoon();
         }
 
         private void hotSwapHelperMenuItem_Click(object sender, EventArgs e)
         {
-            MessageBox.Show("HotSwap Helper not implemented yet.");
+            ShowComingSoon();
+        }
+
+        private void troubleshootingMenuItem_Click(object sender, EventArgs e)
+        {
+            ShowComingSoon();
+        }
+
+        private static void ShowComingSoon()
+        {
+            using var form = new ComingSoonForm();
+            form.ShowDialog();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a MenuStrip with a **More Tools** menu
- show menu items: Create New Library, HotSwap Helper, and Troubleshooting
- open a `ComingSoonForm` for each item

## Testing
- `dotnet build DropFile_I3d/ICam4DSetup.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763a531fc883218c03490a1e0f8858