### PR TITLE
Add Installation menu with IScan and software options

### DIFF
--- a/DropFile_I3d/Form1.Designer.cs
+++ b/DropFile_I3d/Form1.Designer.cs
@@ -35,15 +35,15 @@ namespace DropFile_I3d
             folderBrowserDialog = new FolderBrowserDialog();
             openFileDialog = new OpenFileDialog();
             menuStrip1 = new MenuStrip();
+            installationMenuItem = new ToolStripMenuItem();
+            installIScanMenuItem = new ToolStripMenuItem();
+            otherSoftwareMenuItem = new ToolStripMenuItem();
             moreToolsMenuItem = new ToolStripMenuItem();
             createNewLibraryMenuItem = new ToolStripMenuItem();
             hotSwapHelperMenuItem = new ToolStripMenuItem();
             troubleshootingMenuItem = new ToolStripMenuItem();
             buttonInstallDriver = new Button();
             buttonIScan3d = new Button();
-            buttonInstallZip7 = new Button();
-            buttonInstallOffice = new Button();
-            buttonNotePadPlus = new Button();
             pictureBox1 = new PictureBox();
             buttonRemove = new Button();
             button3 = new Button();
@@ -78,14 +78,35 @@ namespace DropFile_I3d
             openFileDialog.FileName = "openFileDialog";
             // 
             // menuStrip1
-            // 
+            //
             menuStrip1.ImageScalingSize = new Size(24, 24);
-            menuStrip1.Items.AddRange(new ToolStripItem[] { moreToolsMenuItem });
+            menuStrip1.Items.AddRange(new ToolStripItem[] { installationMenuItem, moreToolsMenuItem });
             menuStrip1.Location = new Point(0, 116);
             menuStrip1.Name = "menuStrip1";
             menuStrip1.Size = new Size(624, 33);
             menuStrip1.TabIndex = 30;
             menuStrip1.Text = "menuStrip1";
+            //
+            // installationMenuItem
+            //
+            installationMenuItem.DropDownItems.AddRange(new ToolStripItem[] { installIScanMenuItem, otherSoftwareMenuItem });
+            installationMenuItem.Name = "installationMenuItem";
+            installationMenuItem.Size = new Size(118, 29);
+            installationMenuItem.Text = "Installation";
+            //
+            // installIScanMenuItem
+            //
+            installIScanMenuItem.Name = "installIScanMenuItem";
+            installIScanMenuItem.Size = new Size(208, 34);
+            installIScanMenuItem.Text = "Install IScan";
+            installIScanMenuItem.Click += installIScanMenuItem_Click;
+            //
+            // otherSoftwareMenuItem
+            //
+            otherSoftwareMenuItem.Name = "otherSoftwareMenuItem";
+            otherSoftwareMenuItem.Size = new Size(208, 34);
+            otherSoftwareMenuItem.Text = "Other Software";
+            otherSoftwareMenuItem.Click += otherSoftwareMenuItem_Click;
             // 
             // moreToolsMenuItem
             // 
@@ -142,38 +163,6 @@ namespace DropFile_I3d
             buttonIScan3d.UseVisualStyleBackColor = false;
             buttonIScan3d.Click += buttonIScan3d_Click;
             // 
-            // buttonInstallZip7
-            // 
-            buttonInstallZip7.Location = new Point(18, 35);
-            buttonInstallZip7.Margin = new Padding(4, 5, 4, 5);
-            buttonInstallZip7.Name = "buttonInstallZip7";
-            buttonInstallZip7.Size = new Size(238, 38);
-            buttonInstallZip7.TabIndex = 16;
-            buttonInstallZip7.Text = "Install 7Zip";
-            buttonInstallZip7.UseVisualStyleBackColor = true;
-            buttonInstallZip7.Click += buttonInstallZip7_Click;
-            // 
-            // buttonInstallOffice
-            // 
-            buttonInstallOffice.Location = new Point(18, 83);
-            buttonInstallOffice.Margin = new Padding(4, 5, 4, 5);
-            buttonInstallOffice.Name = "buttonInstallOffice";
-            buttonInstallOffice.Size = new Size(238, 38);
-            buttonInstallOffice.TabIndex = 17;
-            buttonInstallOffice.Text = "Install LibreOffice";
-            buttonInstallOffice.UseVisualStyleBackColor = true;
-            buttonInstallOffice.Click += buttonInstallOffice_Click;
-            // 
-            // buttonNotePadPlus
-            // 
-            buttonNotePadPlus.Location = new Point(18, 131);
-            buttonNotePadPlus.Margin = new Padding(4, 5, 4, 5);
-            buttonNotePadPlus.Name = "buttonNotePadPlus";
-            buttonNotePadPlus.Size = new Size(238, 38);
-            buttonNotePadPlus.TabIndex = 18;
-            buttonNotePadPlus.Text = "Install NotePad ++";
-            buttonNotePadPlus.UseVisualStyleBackColor = true;
-            buttonNotePadPlus.Click += buttonNotePadPlus_Click;
             // 
             // pictureBox1
             // 
@@ -317,10 +306,7 @@ namespace DropFile_I3d
             // groupBox3
             // 
             groupBox3.Controls.Add(buttonInstallDriver);
-            groupBox3.Controls.Add(buttonInstallZip7);
-            groupBox3.Controls.Add(buttonInstallOffice);
             groupBox3.Controls.Add(buttonIScan3d);
-            groupBox3.Controls.Add(buttonNotePadPlus);
             groupBox3.Location = new Point(37, 201);
             groupBox3.Name = "groupBox3";
             groupBox3.Size = new Size(553, 200);
@@ -365,9 +351,6 @@ namespace DropFile_I3d
         private OpenFileDialog openFileDialog;
         private Button buttonInstallDriver;
         private Button buttonIScan3d;
-        private Button buttonInstallZip7;
-        private Button buttonInstallOffice;
-        private Button buttonNotePadPlus;
         private PictureBox pictureBox1;
         private Button button1;
         private EventHandler button1_Click_1;
@@ -385,6 +368,9 @@ namespace DropFile_I3d
         private Label label3;
         private Label label4;
         private MenuStrip menuStrip1;
+        private ToolStripMenuItem installationMenuItem;
+        private ToolStripMenuItem installIScanMenuItem;
+        private ToolStripMenuItem otherSoftwareMenuItem;
         private ToolStripMenuItem moreToolsMenuItem;
         private ToolStripMenuItem createNewLibraryMenuItem;
         private ToolStripMenuItem hotSwapHelperMenuItem;

--- a/DropFile_I3d/Form1.cs
+++ b/DropFile_I3d/Form1.cs
@@ -62,8 +62,8 @@ namespace DropFile_I3d
 
         private void buttonInstallDriver_Click(object sender, EventArgs e)
         {
-            installbat("C:\\I3D_Software\\Drivers\\Camera Flir\\Flir_1.23.0.27_Driver\\install.bat");
-            installInf("C:\\I3D_Software\\Drivers\\Projector Imetric4D 9\\cyusb3.inf");
+            InstallHelpers.InstallBat("C:\\I3D_Software\\Drivers\\Camera Flir\\Flir_1.23.0.27_Driver\\install.bat");
+            InstallHelpers.InstallInf("C:\\I3D_Software\\Drivers\\Projector Imetric4D 9\\cyusb3.inf");
         }
 
         private async void buttonIScan3d_Click(object sender, EventArgs e)
@@ -126,28 +126,7 @@ namespace DropFile_I3d
 
         private void installMsi(string msiPath)
         {
-            try
-            {
-                if (!File.Exists(msiPath))
-                {
-                    MessageBox.Show("MSI file not found: " + msiPath);
-                    return;
-                }
-
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = "msiexec.exe",
-                    Arguments = $"/i \"{msiPath}\" /passive",
-                    UseShellExecute = true,
-                    Verb = "runas"
-                };
-
-                Process.Start(processInfo);
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("MSI install failed: " + ex.Message);
-            }
+            InstallHelpers.InstallMsi(msiPath);
         }
 
         private void buttonInstallOffice_Click(object sender, EventArgs e)
@@ -179,6 +158,22 @@ namespace DropFile_I3d
             }
         }
 
+        private void installIScanMenuItem_Click(object sender, EventArgs e)
+        {
+            var result = MessageBox.Show("Will this computer be using an ICam?", "Install IScan", MessageBoxButtons.YesNo);
+            if (result == DialogResult.Yes)
+            {
+                buttonInstallDriver_Click(sender, e);
+            }
+            buttonIScan3d_Click(sender, e);
+        }
+
+        private void otherSoftwareMenuItem_Click(object sender, EventArgs e)
+        {
+            using var form = new OtherSoftwareForm();
+            form.ShowDialog();
+        }
+
 
 
 
@@ -200,85 +195,17 @@ namespace DropFile_I3d
 
         private void installbat(string batFilePath)
         {
-            try
-            {
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = batFilePath,
-                    Verb = V,
-                    UseShellExecute = true,
-                    CreateNoWindow = true
-                };
-
-                using var process = Process.Start(processInfo);
-                process.WaitForExit();
-                MessageBox.Show("Installation complete.");
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("An error occurred: " + ex.Message);
-            }
+            InstallHelpers.InstallBat(batFilePath);
         }
 
         private void installInf(string batFilePath)
         {
-            try
-            {
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = "powershell.exe",
-                    Arguments = $"-NoProfile -ExecutionPolicy Bypass -Command \"Start-Process pnputil.exe -ArgumentList '/add-driver `{batFilePath}` /install' -Verb RunAs\"",
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                };
-
-                using var process = Process.Start(processInfo);
-                string output = process.StandardOutput.ReadToEnd();
-                string error = process.StandardError.ReadToEnd();
-
-                process.WaitForExit();
-
-                if (!string.IsNullOrEmpty(output)) MessageBox.Show("Output: " + output);
-                if (!string.IsNullOrEmpty(error)) MessageBox.Show("Error: " + error);
-
-                MessageBox.Show("Driver installation complete.");
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("Driver installation failed: " + ex.Message);
-            }
+            InstallHelpers.InstallInf(batFilePath);
         }
 
         private void install(string batFilePath)
         {
-            try
-            {
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = "powershell.exe",
-                    Arguments = $"-NoProfile -ExecutionPolicy Bypass -Command \"& '{batFilePath}'\"",
-                    Verb = V,
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                };
-
-                using var process = Process.Start(processInfo);
-                string output = process.StandardOutput.ReadToEnd();
-                string error = process.StandardError.ReadToEnd();
-
-                process.WaitForExit();
-
-                if (!string.IsNullOrWhiteSpace(output)) MessageBox.Show("Output: " + output);
-                if (!string.IsNullOrWhiteSpace(error)) MessageBox.Show("Error: " + error);
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show("An error occurred: " + ex.Message);
-            }
+            InstallHelpers.Install(batFilePath);
         }
 
         private void buttonEditor_Click(object sender, EventArgs e)

--- a/DropFile_I3d/InstallHelpers.cs
+++ b/DropFile_I3d/InstallHelpers.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
+
+namespace DropFile_I3d
+{
+    internal static class InstallHelpers
+    {
+        private const string VerbRunAs = "runas";
+
+        public static void InstallBat(string batFilePath)
+        {
+            try
+            {
+                var processInfo = new ProcessStartInfo
+                {
+                    FileName = batFilePath,
+                    Verb = VerbRunAs,
+                    UseShellExecute = true,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(processInfo);
+                process.WaitForExit();
+                MessageBox.Show("Installation complete.");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("An error occurred: " + ex.Message);
+            }
+        }
+
+        public static void InstallInf(string infPath)
+        {
+            try
+            {
+                var processInfo = new ProcessStartInfo
+                {
+                    FileName = "powershell.exe",
+                    Arguments = $"-NoProfile -ExecutionPolicy Bypass -Command \"Start-Process pnputil.exe -ArgumentList '/add-driver `{infPath}` /install' -Verb RunAs\"",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+
+                using var process = Process.Start(processInfo);
+                string output = process.StandardOutput.ReadToEnd();
+                string error = process.StandardError.ReadToEnd();
+
+                process.WaitForExit();
+
+                if (!string.IsNullOrEmpty(output)) MessageBox.Show("Output: " + output);
+                if (!string.IsNullOrEmpty(error)) MessageBox.Show("Error: " + error);
+
+                MessageBox.Show("Driver installation complete.");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Driver installation failed: " + ex.Message);
+            }
+        }
+
+        public static void Install(string scriptPath)
+        {
+            try
+            {
+                var processInfo = new ProcessStartInfo
+                {
+                    FileName = "powershell.exe",
+                    Arguments = $"-NoProfile -ExecutionPolicy Bypass -Command \"& '{scriptPath}'\"",
+                    Verb = VerbRunAs,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+
+                using var process = Process.Start(processInfo);
+                string output = process.StandardOutput.ReadToEnd();
+                string error = process.StandardError.ReadToEnd();
+
+                process.WaitForExit();
+
+                if (!string.IsNullOrWhiteSpace(output)) MessageBox.Show("Output: " + output);
+                if (!string.IsNullOrWhiteSpace(error)) MessageBox.Show("Error: " + error);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("An error occurred: " + ex.Message);
+            }
+        }
+
+        public static void InstallMsi(string msiPath)
+        {
+            try
+            {
+                if (!File.Exists(msiPath))
+                {
+                    MessageBox.Show("MSI file not found: " + msiPath);
+                    return;
+                }
+
+                var processInfo = new ProcessStartInfo
+                {
+                    FileName = "msiexec.exe",
+                    Arguments = $"/i \"{msiPath}\" /passive",
+                    UseShellExecute = true,
+                    Verb = VerbRunAs
+                };
+
+                Process.Start(processInfo);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("MSI install failed: " + ex.Message);
+            }
+        }
+    }
+}

--- a/DropFile_I3d/OtherSoftwareForm.cs
+++ b/DropFile_I3d/OtherSoftwareForm.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace DropFile_I3d
+{
+    public class OtherSoftwareForm : Form
+    {
+        private Button buttonZip;
+        private Button buttonOffice;
+        private Button buttonNotepad;
+
+        public OtherSoftwareForm()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            buttonZip = new Button();
+            buttonOffice = new Button();
+            buttonNotepad = new Button();
+            SuspendLayout();
+
+            // buttonZip
+            buttonZip.Location = new Point(20, 20);
+            buttonZip.Size = new Size(238, 38);
+            buttonZip.Text = "Install 7Zip";
+            buttonZip.Click += ButtonZip_Click;
+
+            // buttonOffice
+            buttonOffice.Location = new Point(20, 68);
+            buttonOffice.Size = new Size(238, 38);
+            buttonOffice.Text = "Install LibreOffice";
+            buttonOffice.Click += ButtonOffice_Click;
+
+            // buttonNotepad
+            buttonNotepad.Location = new Point(20, 116);
+            buttonNotepad.Size = new Size(238, 38);
+            buttonNotepad.Text = "Install NotePad ++";
+            buttonNotepad.Click += ButtonNotepad_Click;
+
+            // Form
+            AutoScaleDimensions = new SizeF(10F, 25F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(278, 176);
+            Controls.Add(buttonZip);
+            Controls.Add(buttonOffice);
+            Controls.Add(buttonNotepad);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Other Software";
+            ResumeLayout(false);
+        }
+
+        private void ButtonZip_Click(object? sender, EventArgs e)
+        {
+            InstallHelpers.Install(@"C:\I3D_Software\General\7zip\7z1900-x64.exe");
+        }
+
+        private void ButtonOffice_Click(object? sender, EventArgs e)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", "https://www.libreoffice.org/download/download-libreoffice"));
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("An error occurred: " + ex.Message);
+            }
+        }
+
+        private void ButtonNotepad_Click(object? sender, EventArgs e)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", "https://notepad-plus-plus.org/downloads/"));
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("An error occurred: " + ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new InstallHelpers helper class
- add `OtherSoftwareForm` with install links
- create Installation menu with IScan installer and Other Software dialog
- move software install buttons off the main form

## Testing
- `apt-get update` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_687655a95758832196e2240f191b33a0