### PR TITLE
Implement calibration file replacement

### DIFF
--- a/DropFile_I3d/CalibrationPlateForm.cs
+++ b/DropFile_I3d/CalibrationPlateForm.cs
@@ -1,14 +1,25 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 namespace DropFile_I3d
 {
     public partial class CalibrationPlateForm : Form
     {
-        public CalibrationPlateForm()
+        private readonly string destRef;
+        private string cpFilePath = string.Empty;
+        private string rdFilePath = string.Empty;
+
+        public CalibrationPlateForm() : this(string.Empty)
+        {
+        }
+
+        public CalibrationPlateForm(string destRef)
         {
             InitializeComponent();
+            this.destRef = destRef;
             dropBox1.AllowDrop = true;
             dropBox2.AllowDrop = true;
             dropBox1.DragEnter += Drop_DragEnter;
@@ -27,14 +38,61 @@ namespace DropFile_I3d
         {
             var files = (string[])e.Data.GetData(DataFormats.FileDrop);
             if (files.Length > 0)
-                dropBox1.Text = Path.GetFileName(files[0]);
+            {
+                cpFilePath = files[0];
+                dropBox1.Text = Path.GetFileName(cpFilePath);
+                TryUpdateCalibration();
+            }
         }
 
         private void DropBox2_DragDrop(object sender, DragEventArgs e)
         {
             var files = (string[])e.Data.GetData(DataFormats.FileDrop);
             if (files.Length > 0)
-                dropBox2.Text = Path.GetFileName(files[0]);
+            {
+                rdFilePath = files[0];
+                dropBox2.Text = Path.GetFileName(rdFilePath);
+                TryUpdateCalibration();
+            }
+        }
+
+        private void TryUpdateCalibration()
+        {
+            if (File.Exists(cpFilePath) && File.Exists(rdFilePath) && Directory.Exists(destRef))
+            {
+                UpdateCalibrationFiles();
+                MessageBox.Show("Calibration files updated.");
+                Close();
+            }
+        }
+
+        private void UpdateCalibrationFiles()
+        {
+            string cpDest = Path.Combine(destRef, Path.GetFileName(cpFilePath));
+            File.Copy(cpFilePath, cpDest, true);
+
+            string rdDest = Path.Combine(destRef, Path.GetFileName(rdFilePath));
+            File.Copy(rdFilePath, rdDest, true);
+
+            string rdBase = Path.GetFileNameWithoutExtension(rdDest);
+            string newIpd1 = Path.Combine(destRef, rdBase + "_IPD1.obr");
+            var oldIpd1 = Directory.GetFiles(destRef, "RD_CP100_*_IPD1.obr").FirstOrDefault();
+            if (oldIpd1 != null)
+            {
+                if (File.Exists(newIpd1))
+                    File.Delete(newIpd1);
+                File.Move(oldIpd1, newIpd1);
+            }
+
+            string refFile = Path.Combine(destRef, "Reference_setup.txt");
+            if (File.Exists(refFile))
+            {
+                string text = File.ReadAllText(refFile);
+                text = Regex.Replace(text, @"CP100_\d+\.obr", Path.GetFileName(cpDest));
+                text = Regex.Replace(text, @"RD_CP100_\d+\.obr", Path.GetFileName(rdDest));
+                text = Regex.Replace(text, @"RD_CP100_\d+_IPD1\.obr", Path.GetFileName(newIpd1));
+                File.WriteAllText(refFile, text);
+            }
         }
     }
 }

--- a/DropFile_I3d/CalibrationQuestionForm.cs
+++ b/DropFile_I3d/CalibrationQuestionForm.cs
@@ -40,7 +40,8 @@ namespace DropFile_I3d
 
         private void buttonNo_Click(object sender, EventArgs e)
         {
-            using var calibForm = new CalibrationPlateForm();
+            string destRef = Path.Combine(newIcamFolder, "0References");
+            using var calibForm = new CalibrationPlateForm(destRef);
             calibForm.ShowDialog();
             Close();
         }


### PR DESCRIPTION
## Summary
- update `CalibrationPlateForm` to copy new calibration files into the `0References` folder
- rename the IPD1 file to match the dragged RD calibration file
- update `Reference_setup.txt` with the new names
- pass the reference folder path from `CalibrationQuestionForm`

## Testing
- `dotnet build DropFile_I3d/ICam4DSetup.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766e009e788321abec37a592bcbc4c