### PR TITLE
Archive overwritten calibration files

### DIFF
--- a/DropFile_I3d/CalibrationPlateForm.cs
+++ b/DropFile_I3d/CalibrationPlateForm.cs
@@ -68,6 +68,25 @@ namespace DropFile_I3d
 
         private void UpdateCalibrationFiles()
         {
+            string archiveDir = Path.Combine(destRef, "_0Archive");
+            Directory.CreateDirectory(archiveDir);
+
+            foreach (var file in Directory.GetFiles(destRef, "CP100_*.obr"))
+            {
+                string target = Path.Combine(archiveDir, Path.GetFileName(file));
+                if (File.Exists(target))
+                    File.Delete(target);
+                File.Move(file, target);
+            }
+
+            foreach (var file in Directory.GetFiles(destRef, "RD_CP100_*.obr").Where(f => !f.Contains("_IPD1")))
+            {
+                string target = Path.Combine(archiveDir, Path.GetFileName(file));
+                if (File.Exists(target))
+                    File.Delete(target);
+                File.Move(file, target);
+            }
+
             string cpDest = Path.Combine(destRef, Path.GetFileName(cpFilePath));
             File.Copy(cpFilePath, cpDest, true);
 


### PR DESCRIPTION
## Summary
- keep old CP100/RD_CP100 calibration files instead of overwriting them
- archive old files inside `_0Archive`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68767449fdbc83218c3881b9e300e2d1