### PR TITLE
Support ICamBodyLibrary folder names

### DIFF
--- a/DropFile_I3d/Form1.cs
+++ b/DropFile_I3d/Form1.cs
@@ -419,7 +419,10 @@ namespace DropFile_I3d
             if (!Directory.Exists(baseDir))
                 return;
 
-            var dirs = Directory.GetDirectories(baseDir, "*ICamBody Library", SearchOption.TopDirectoryOnly);
+            var dirs = Directory.GetDirectories(baseDir, "*", SearchOption.TopDirectoryOnly)
+                .Where(d => d.Contains("ICamBody Library", StringComparison.OrdinalIgnoreCase)
+                         || d.Contains("ICamBodyLibrary", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
             foreach (var dir in dirs)
             {
                 string folderName = Path.GetFileName(dir);

--- a/DropFile_I3d/HotSwapHelperForm.cs
+++ b/DropFile_I3d/HotSwapHelperForm.cs
@@ -32,7 +32,10 @@ namespace DropFile_I3d
             comboBoxOldIcam.Items.Clear();
             if (!Directory.Exists(baseDir))
                 return;
-            var dirs = Directory.GetDirectories(baseDir, "*ICamBody Library", SearchOption.TopDirectoryOnly);
+            var dirs = Directory.GetDirectories(baseDir, "*", SearchOption.TopDirectoryOnly)
+                .Where(d => d.Contains("ICamBody Library", StringComparison.OrdinalIgnoreCase)
+                         || d.Contains("ICamBodyLibrary", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
             foreach (var dir in dirs)
             {
                 string folderName = Path.GetFileName(dir);


### PR DESCRIPTION
## Summary
- search for both `ICamBody Library` and `ICamBodyLibrary` folders
- populate dropdowns using whichever variant is found

## Testing
- `dotnet build Imetric_Installer.sln -c Release` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767b58704483218524c8199af36c10